### PR TITLE
Detach pending mapping entities, too

### DIFF
--- a/src/Db/Event/Listener/DetachOrphanMappings.php
+++ b/src/Db/Event/Listener/DetachOrphanMappings.php
@@ -39,5 +39,14 @@ class DetachOrphanMappings
                 }
             }
         }
+
+        $insertions = $uow->getScheduledEntityInsertions();
+        foreach ($insertions as $entity) {
+            if (($entity instanceof Mapping && !$em->contains($entity->getItem()))
+                || ($entity instanceof MappingMarker && (!$em->contains($entity->getItem()) || ($entity->getMedia() && !$em->contains($entity->getMedia()))))
+            ) {
+                $em->detach($entity);
+            }
+        }
     }
 }


### PR DESCRIPTION
The event listener we use to fix the situation where a Mapping entity
refers to a detached/non-existent Item (or Media) doesn't work in the
case where the mapping entity is _new_.

We need to look in the pending insertions from the Doctrine unit of work
in that case.

This problem manifests as errors during imports when an item isn't
actually persisted due to an error (the concrete example here being an
Omeka2Importer import where some items were not created due to a mime
type issue for their files; stray Mapping entities converted those
skipped items into a fatal error.