### PR TITLE
Fix warning during Omeka2Importer import

### DIFF
--- a/src/Omeka2Importer/GeolocationImporter.php
+++ b/src/Omeka2Importer/GeolocationImporter.php
@@ -9,7 +9,7 @@ class GeolocationImporter extends AbstractImporter
     public function import($itemData, $resourceJson)
     {
         $logger = $this->getServiceLocator()->get('Omeka\Logger');
-        $geolocationId = $itemData['extended_resources']['geolocations']['id'];
+        $geolocationId = $itemData['extended_resources']['geolocations']['id'] ?? null;
         if (empty($geolocationId)) {
             return $resourceJson;
         }


### PR DESCRIPTION
The Omeka 2 Importer code for Mapping generates warnings about missing array keys, fixed by using the null coalescing operator.