### PR TITLE
Fix roundtrip hydrate

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -3,6 +3,7 @@ namespace Mapping;
 
 use Doctrine\ORM\Events;
 use Mapping\Db\Event\Listener\DetachOrphanMappings;
+use Omeka\Api\Exception as ApiException;
 use Omeka\Module\AbstractModule;
 use Omeka\Permissions\Acl;
 use Laminas\EventManager\Event;
@@ -412,6 +413,7 @@ class Module extends AbstractModule
     {
         $itemAdapter = $event->getTarget();
         $request = $event->getParam('request');
+        $item = $event->getParam('entity');
 
         if (!$itemAdapter->shouldHydrate($request, 'o-module-mapping:mapping')) {
             return;
@@ -420,46 +422,49 @@ class Module extends AbstractModule
         $mappingsAdapter = $itemAdapter->getAdapter('mappings');
         $mappingData = $request->getValue('o-module-mapping:mapping', []);
 
-        $mappingId = null;
         $bounds = null;
 
-        if (isset($mappingData['o:id']) && is_numeric($mappingData['o:id'])) {
-            $mappingId = $mappingData['o:id'];
-        }
         if (isset($mappingData['o-module-mapping:bounds'])
             && '' !== trim($mappingData['o-module-mapping:bounds'])
         ) {
             $bounds = $mappingData['o-module-mapping:bounds'];
         }
 
-        if (null === $bounds) {
-            // This request has no mapping data. If a mapping for this item
-            // exists, delete it. If no mapping for this item exists, do nothing.
-            if (null !== $mappingId) {
-                // Delete mapping
-                $subRequest = new \Omeka\Api\Request('delete', 'mappings');
-                $subRequest->setId($mappingId);
-                $mappingsAdapter->deleteEntity($subRequest);
-            }
+        // Skip updates if passed mapping data is only a reference; just retain it
+        if (!array_diff_key($mappingData, array_flip(['@id', 'o:id']))) {
+            return;
+        }
+
+        try {
+            $mapping = $mappingsAdapter->findEntity(['item' => $item]);
+        } catch (ApiException\NotFoundException $e) {
+            $mapping = null;
+        }
+
+        if ($mapping && (null === $bounds)) {
+            // This request has no mapping data. If a mapping for this item exists, delete it.
+            $subRequest = new \Omeka\Api\Request('delete', 'mappings');
+            $subRequest->setId($mapping->getId());
+            $mappingsAdapter->deleteEntity($subRequest);
+            return;
+        }
+
+        // This request has mapping data. If a mapping for this item exists,
+        // update it. If no mapping for this item exists, create it.
+        if ($mapping) {
+            // Update mapping
+            $subRequest = new \Omeka\Api\Request('update', 'mappings');
+            $subRequest->setId($mappingData['o:id']);
+            $subRequest->setContent($mappingData);
+            $mappingsAdapter->hydrateEntity($subRequest, $mapping, new \Omeka\Stdlib\ErrorStore);
         } else {
-            // This request has mapping data. If a mapping for this item exists,
-            // update it. If no mapping for this item exists, create it.
-            if ($mappingId) {
-                // Update mapping
-                $subRequest = new \Omeka\Api\Request('update', 'mappings');
-                $subRequest->setId($mappingData['o:id']);
-                $subRequest->setContent($mappingData);
-                $mapping = $mappingsAdapter->findEntity($mappingData['o:id'], $subRequest);
-                $mappingsAdapter->hydrateEntity($subRequest, $mapping, new \Omeka\Stdlib\ErrorStore);
-            } else {
-                // Create mapping
-                $subRequest = new \Omeka\Api\Request('create', 'mappings');
-                $subRequest->setContent($mappingData);
-                $mapping = new \Mapping\Entity\Mapping;
-                $mapping->setItem($event->getParam('entity'));
-                $mappingsAdapter->hydrateEntity($subRequest, $mapping, new \Omeka\Stdlib\ErrorStore);
-                $mappingsAdapter->getEntityManager()->persist($mapping);
-            }
+            // Create mapping
+            $subRequest = new \Omeka\Api\Request('create', 'mappings');
+            $subRequest->setContent($mappingData);
+            $mapping = new \Mapping\Entity\Mapping;
+            $mapping->setItem($event->getParam('entity'));
+            $mappingsAdapter->hydrateEntity($subRequest, $mapping, new \Omeka\Stdlib\ErrorStore);
+            $mappingsAdapter->getEntityManager()->persist($mapping);
         }
     }
 

--- a/Module.php
+++ b/Module.php
@@ -4,6 +4,7 @@ namespace Mapping;
 use Doctrine\ORM\Events;
 use Mapping\Db\Event\Listener\DetachOrphanMappings;
 use Omeka\Api\Exception as ApiException;
+use Omeka\Api\Request;
 use Omeka\Module\AbstractModule;
 use Omeka\Permissions\Acl;
 use Laminas\EventManager\Event;
@@ -435,10 +436,13 @@ class Module extends AbstractModule
             return;
         }
 
-        try {
-            $mapping = $mappingsAdapter->findEntity(['item' => $item]);
-        } catch (ApiException\NotFoundException $e) {
-            $mapping = null;
+        $mapping = null;
+        if (Request::CREATE !== $request->getOperation()) {
+            try {
+                $mapping = $mappingsAdapter->findEntity(['item' => $item]);
+            } catch (ApiException\NotFoundException $e) {
+                // no action
+            }
         }
 
         if (null === $bounds) {

--- a/Module.php
+++ b/Module.php
@@ -441,11 +441,13 @@ class Module extends AbstractModule
             $mapping = null;
         }
 
-        if ($mapping && (null === $bounds)) {
+        if (null === $bounds) {
             // This request has no mapping data. If a mapping for this item exists, delete it.
-            $subRequest = new \Omeka\Api\Request('delete', 'mappings');
-            $subRequest->setId($mapping->getId());
-            $mappingsAdapter->deleteEntity($subRequest);
+            if ($mapping) {
+                $subRequest = new \Omeka\Api\Request('delete', 'mappings');
+                $subRequest->setId($mapping->getId());
+                $mappingsAdapter->deleteEntity($subRequest);
+            }
             return;
         }
 

--- a/Module.php
+++ b/Module.php
@@ -489,8 +489,12 @@ class Module extends AbstractModule
                 $subRequest->setId($markerData['o:id']);
                 $subRequest->setContent($markerData);
                 $marker = $markersAdapter->findEntity($markerData['o:id'], $subRequest);
-                $markersAdapter->hydrateEntity($subRequest, $marker, new \Omeka\Stdlib\ErrorStore);
                 $retainMarkerIds[] = $marker->getId();
+
+                // Skip subrequest if passed marker data is only a reference; just retain it
+                if (array_diff_key($markerData, array_flip(['@id', 'o:id']))) {
+                    $markersAdapter->hydrateEntity($subRequest, $marker, new \Omeka\Stdlib\ErrorStore);
+                }
             } else {
                 $subRequest = new \Omeka\Api\Request('create', 'mapping_markers');
                 $subRequest->setContent($markerData);


### PR DESCRIPTION
This PR contains minimal fixes to Mapping's "round-trip hydration" issues. Put shortly, the module has a problem where its output to the API doesn't match well with its expected input, so feeding the API's output back into the API leads to undesirable results when mapping data is present on items being updated.

This was first reported in the context of CSV Import which does this kind of "feed the API to itself" process when updating, but the same problems occur for direct usage of the API, internally or via REST.

The individual commits describe the fixes in more detail, but the upshot is that these are simple workaround fixes for just the basic round-tripping problem. A more involved solution probably involves getting IDs out of the API additions for Mapping in some situations and perhaps including the relevant map data directly in the item responses, but this purposely leaves the basic system in place and just carves out "make no change" conditions for the case of feeding the mapping data back in untouched.

This addresses issues reported in #97 and #98.